### PR TITLE
feat(C1): fix artifact transition between C1 missions

### DIFF
--- a/UserMODs/MMH55-Cam-Maps/Maps/Scenario/C1M4/MapScript.lua
+++ b/UserMODs/MMH55-Cam-Maps/Maps/Scenario/C1M4/MapScript.lua
@@ -255,6 +255,7 @@ OBJECTIVES = {
         end
         
         if GetObjectiveState( "prim1") == OBJECTIVE_COMPLETED then
+		  Save("scene2" );
           sleep(5);
           Win();
           return

--- a/UserMODs/MMH55-Cam-Maps/Maps/Scenario/C1M5/MapScript.lua
+++ b/UserMODs/MMH55-Cam-Maps/Maps/Scenario/C1M5/MapScript.lua
@@ -317,6 +317,7 @@ OBJECTIVES = {
       end
       
       if GetObjectiveState( "prim5") == OBJECTIVE_COMPLETED then
+	    Save("scene3" );
         CINEMATICS.outro();
 	  	  Win();
 	  	  return


### PR DESCRIPTION
these saves are necessary,  the game uses them to migrate artifacts between missions.